### PR TITLE
Add conan 2.0 compatibility

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -1,13 +1,13 @@
-name: Deploy Conan 1.x Package
+name: Deploy Conan 2.x Package
 
 on: [push]
 
 jobs:
-  linux:
+  deploy:
     name: "Build and Deploy to Mount Olympus"
     runs-on: ubuntu-latest
     container:
-      image: "samuelemrys/gcc12-ubuntu18.04:1.59.0"
+      image: "samuelemrys/gcc12-ubuntu18.04:latest"
       options: --user root
     steps:
       - name: checkout
@@ -16,11 +16,12 @@ jobs:
         shell: bash
         run: |
           conan remote add mtolympus https://mtolympus.jfrog.io/artifactory/api/conan/mtolympus-conan
-          conan user -p ${{ secrets.MOUNT_OLYMPUS_DEPLOYMENT_TOKEN }} -r mtolympus ${{ secrets.MOUNT_OLYMPUS_DEPLOYMENT_USER }}
+          conan remote login mtolympus ${{ secrets.MOUNT_OLYMPUS_DEPLOYMENT_USER }} -p ${{ secrets.MOUNT_OLYMPUS_DEPLOYMENT_TOKEN }}
+          conan profile detect
       - name: create package
         shell: bash
         run: |
-          conan create . system@mtolympus/stable -pr:h default -pr:b default -tf test_v1_package
+          conan create . --user mtolympus --channel stable -pr:h default -pr:b default
       - name: deploy package
         if: github.ref == 'refs/heads/master' && success()
         shell: bash
@@ -38,11 +39,12 @@ jobs:
           python-version: '3.11'
       - name: install conan
         run: |
-          pip install conan==1.59.0
+          pip install conan
       - name: configure conan
         run: |
-          conan config set general.revisions_enabled=1
           conan remote add mtolympus https://mtolympus.jfrog.io/artifactory/api/conan/mtolympus-conan
+          conan profile detect
       - name: create package
         run: |
-          conan create . system@mtolympus/stable -pr:h default -pr:b default -tf test_v1_package
+          conan create . --user mtolympus --channel stable -pr:h default -pr:b default
+

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -21,12 +21,12 @@ jobs:
       - name: create package
         shell: bash
         run: |
-          conan create . --user mtolympus --channel stable -pr:h default -pr:b default
+          conan create . --user mtolympus --channel stable -pr:h default -pr:b default -o:b 'python-virtualenv/*:requirements=["sphinx","sphinx-rtd-theme"]' --build-require -tf test_package
       - name: deploy package
         if: github.ref == 'refs/heads/master' && success()
         shell: bash
         run: |
-          conan upload python-virtualenv/system@mtolympus/stable -r mtolympus -c
+          conan upload python-virtualenv/system@mtolympus/stable --only-recipe -r mtolympus -c
   windows:
     name: "Build Windows"
     runs-on: windows-latest
@@ -46,5 +46,5 @@ jobs:
           conan profile detect
       - name: create package
         run: |
-          conan create . --user mtolympus --channel stable -pr:h default -pr:b default
+          conan create . --user mtolympus --channel stable -pr:h default -pr:b default -o:b python-virtualenv/*:requirements='[\"sphinx\",\"sphinx-rtd-theme\"]' --build-require -tf test_package
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 # Build
 build/
+
+# Conan
+conanbuild.sh
+conanbuildenv-release-x86_64.sh
+conanrun.sh
+conanrunenv-release-x86_64.sh
+deactivate_conanbuild.sh
+deactivate_conanbuildenv-release-x86_64.sh
+deactivate_conanrun.sh
+deactivate_conanrunenv-release-x86_64.sh
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-virtualenv
 
-A conan recipe to build a python virtual environment. This should be used in conjunction with the [CMakePythonDeps](https://github.com/samuel-emrys/pyvenv) generator.
+A conan recipe to build a python virtual environment. This should be used in conjunction with the [CMakePythonDeps](https://github.com/samuel-emrys/cmake-python-deps) generator.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The first, below, demonstrates how to specify these requirements directly in the
 class VirtualenvConsumerConan(ConanFile):
     name = "venv-consumer"
     version = "0.1.0"
-    python_requires = "CMakePythonDeps/0.2.0@mtolympus/stable"
+    python_requires = "cmake-python-deps/[>=0.3.0]@mtolympus/stable"
 
     def requirements(self):
         self.requires("python-virtualenv/system@mtolympus/stable")
@@ -29,7 +29,7 @@ class VirtualenvConsumerConan(ConanFile):
         ])
 
     def generate(self):
-        py = self.python_requires["CMakePythonDeps"].module.CMakePythonDeps(self)
+        py = self.python_requires["cmake-python-deps"].module.CMakePythonDeps(self)
         py.generate()
 ```
 
@@ -41,7 +41,7 @@ class VirtualenvConsumerConan(ConanFile):
     version = "0.1.0"
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "requirements.txt"
-    python_requires = "CMakePythonDeps/0.2.0@mtolympus/stable"
+    python_requires = "cmake-python-deps/[>=0.3.0]@mtolympus/stable"
 
     def requirements(self):
         self.requires("python-virtualenv/system@mtolympus/stable")
@@ -52,7 +52,7 @@ class VirtualenvConsumerConan(ConanFile):
             ])
 
     def generate(self):
-        py = self.python_requires["CMakePythonDeps"].module.CMakePythonDeps(self)
+        py = self.python_requires["cmake-python-deps"].module.CMakePythonDeps(self)
         py.generate()
 ```
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,6 +21,7 @@ class PythonVirtualEnvironment(ConanFile):
     python_requires = "pyvenv/[>=0.1.1]@mtolympus/stable"
     # python venvs are not relocatable, so we will not have binaries for this on artifactory. Just build it on first use
     build_policy = "missing"
+    upload_policy = "skip"
     _venv = None
 
     def validate(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,7 @@ class PythonVirtualEnvironment(ConanFile):
             json.loads(str(self.options.requirements))
         except Exception as e:
             raise ConanInvalidConfiguration(
-                "Failed to parse requirements. Ensure requirements are passed as valid JSON."
+                f"Failed to parse requirements '{self.options.requirements}'. Ensure requirements are passed as valid JSON."
             )
 
     @property

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -12,12 +12,7 @@ class PythonVirtualenvTestConan(ConanFile):
     test_type = "explicit"
 
     def build_requirements(self):
-        self.tool_requires(self.tested_reference_str, options={
-            "requirements": json.dumps([
-                "sphinx",
-                "sphinx-rtd-theme",
-            ])
-        })
+        self.tool_requires(self.tested_reference_str)
 
     def test(self):
         if not cross_building(self):
@@ -37,5 +32,6 @@ class PythonVirtualenvTestConan(ConanFile):
             self.output.info(f"user.env.pythonenv:requirements={requirements}")
             self.output.info("Executing `python --version`")
             self.run("python --version", env="conanbuild")
-            self.output.info("Executing `sphinx-build --help`")
-            self.run("sphinx-build --help", env="conanbuild")
+            if "sphinx" in json.loads(requirements):
+                self.output.info("Executing `sphinx-build --help`")
+                self.run("sphinx-build --help", env="conanbuild")

--- a/test_v1_package/conanfile.py
+++ b/test_v1_package/conanfile.py
@@ -11,13 +11,14 @@ class PythonVirtualenvTestConan(ConanFile):
     apply_env = False
     test_type = "explicit"
 
+    def configure(self):
+        self.options["python-virtualenv"].requirements = json.dumps([
+            "sphinx",
+            "sphinx-rtd-theme",
+        ])
+
     def build_requirements(self):
-        self.tool_requires(self.tested_reference_str, options={
-            "requirements": json.dumps([
-                "sphinx",
-                "sphinx-rtd-theme",
-            ])
-        })
+        self.tool_requires(self.tested_reference_str)
 
     def test(self):
         if not cross_building(self):


### PR DESCRIPTION
Add conan 2.0 compatibility:
* Add deployment for conan 2.0 package
* Fix the CI conan version to 1.59.0
* Add test_v1_package
* Update documentation
* Add additional debugging to `validate()` error message
* Move the options for the tool_requires in the test package out to command line arguments. This is because these requirements aren't propagated to what's built by `conan create`.
* Add `upload_policy="skip"` to the recipe to ensure binary artifacts aren't uploaded with the recipe
* Bump pyvenv requirement to >=0.2.2 to bring in relocation functionality in support of conan 2's lack of support for non-relocatable packages.

Closes #6